### PR TITLE
hotfix: Fix image_index_error

### DIFF
--- a/sxs/utils.py
+++ b/sxs/utils.py
@@ -142,7 +142,10 @@ def get_landcover_type2(lat_P, lon_P, lcv_mask):
     lat_index = math.ceil((lat_max - lat_P) / lat_res) - 1
     lon_index = math.ceil((lon_P - lon_min) / lon_res) - 1
 
-    lcv_RGB1 = lcv_mask.getpixel((lon_index, lat_index))
+    try:
+        lcv_RGB1 = lcv_mask.getpixel((lon_index, lat_index))
+    except IndexError:
+        lcv_RGB1 = (255, 255, 255, 255)
     # drop alpha channel in index 3
     lcv_RGB = tuple([z / 255 for z in lcv_RGB1[:3]])
     color = [


### PR DESCRIPTION
Provides a fix for the image index error when the specular point falls outside the landcover map. When this happens the returned value will now be -1. It also provides a fix for the requested XI is out of bounds in sp_solver function. If the point is outside the landmask it will not process this point